### PR TITLE
Add `TrackingGeometry` visualization

### DIFF
--- a/acts-sys/build.rs
+++ b/acts-sys/build.rs
@@ -51,6 +51,7 @@ fn main() {
         "src/utilities/logger.rs",
         "src/utilities/proto_axis.rs",
         "src/visualization/i_visualization3d.rs",
+        "src/visualization/obj_visualization3d.rs",
     ];
     let cpp_files = vec!["src/definitions/algebra.cpp"];
     cxx_build::bridges(bridge_files)

--- a/acts-sys/build.rs
+++ b/acts-sys/build.rs
@@ -50,6 +50,7 @@ fn main() {
         "src/utilities/axis_definitions.rs",
         "src/utilities/logger.rs",
         "src/utilities/proto_axis.rs",
+        "src/visualization/i_visualization3d.rs",
     ];
     let cpp_files = vec!["src/definitions/algebra.cpp"];
     cxx_build::bridges(bridge_files)

--- a/acts-sys/build.rs
+++ b/acts-sys/build.rs
@@ -52,6 +52,7 @@ fn main() {
         "src/utilities/proto_axis.rs",
         "src/visualization/i_visualization3d.rs",
         "src/visualization/obj_visualization3d.rs",
+        "src/visualization/view_config.rs",
     ];
     let cpp_files = vec!["src/definitions/algebra.cpp"];
     cxx_build::bridges(bridge_files)

--- a/acts-sys/include/geometry/blueprint.hpp
+++ b/acts-sys/include/geometry/blueprint.hpp
@@ -16,11 +16,10 @@ new_blueprint_config(const Acts::ExtentEnvelope &envelope) {
   return cfg;
 }
 
-inline Acts::Experimental::Blueprint &
+inline void
 blueprint_add_child(Acts::Experimental::Blueprint &node,
                     std::shared_ptr<Acts::Experimental::BlueprintNode> child) {
-  return static_cast<Acts::Experimental::Blueprint &>(
-      node.addChild(std::move(child)));
+  node.addChild(std::move(child));
 }
 
 } // namespace ffi

--- a/acts-sys/include/visualization/i_visualization3d.hpp
+++ b/acts-sys/include/visualization/i_visualization3d.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Acts/Visualization/IVisualization3D.hpp"
+#include <filesystem>
+
+namespace acts_sys {
+namespace ffi {
+
+inline void i_visualization3d_write(const Acts::IVisualization3D &vis,
+                                    const std::string &path) {
+  std::filesystem::path fs_path = path;
+  vis.write(fs_path);
+}
+
+} // namespace ffi
+} // namespace acts_sys

--- a/acts-sys/include/visualization/view_config.hpp
+++ b/acts-sys/include/visualization/view_config.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Acts/Visualization/ViewConfig.hpp"
+#include <memory>
+
+namespace acts_sys {
+namespace ffi {
+
+inline std::unique_ptr<Acts::ViewConfig>
+new_view_config(bool visible, const std::array<int, 3> &rgb_color,
+                double offset, double line_thickness, double surface_thickness,
+                unsigned int quarter_segments, bool triangulate,
+                const std::string &output_name) {
+  auto cfg = std::make_unique<Acts::ViewConfig>();
+  cfg->visible = visible;
+  cfg->color = Acts::Color(rgb_color);
+  cfg->offset = offset;
+  cfg->lineThickness = line_thickness;
+  cfg->surfaceThickness = surface_thickness;
+  cfg->quarterSegments = quarter_segments;
+  cfg->triangulate = triangulate;
+  cfg->outputName = std::filesystem::path(output_name);
+
+  return cfg;
+}
+
+} // namespace ffi
+} // namespace acts_sys

--- a/acts-sys/include/visualization/view_config.hpp
+++ b/acts-sys/include/visualization/view_config.hpp
@@ -19,7 +19,7 @@ new_view_config(bool visible, const std::array<int, 3> &rgb_color,
   cfg->surfaceThickness = surface_thickness;
   cfg->quarterSegments = quarter_segments;
   cfg->triangulate = triangulate;
-  cfg->outputName = std::filesystem::path(output_name);
+  cfg->outputName = output_name;
 
   return cfg;
 }

--- a/acts-sys/src/geometry/blueprint.rs
+++ b/acts-sys/src/geometry/blueprint.rs
@@ -31,7 +31,7 @@ mod ffi {
         fn blueprint_add_child(
             node: Pin<&mut Blueprint>,
             child: SharedPtr<BlueprintNode>,
-        ) -> Result<Pin<&mut Blueprint>>;
+        ) -> Result<()>;
 
         #[namespace = "acts_sys::ffi"]
         fn new_blueprint_config(envelope: &ExtentEnvelope) -> UniquePtr<BlueprintConfig>;

--- a/acts-sys/src/geometry/layer_blueprint_node.rs
+++ b/acts-sys/src/geometry/layer_blueprint_node.rs
@@ -92,4 +92,6 @@ mod ffi {
         #[namespace = "acts_sys::ffi"]
         type SharedSurface = crate::geometry::layer_blueprint_node::SharedSurface;
     }
+
+    impl CxxVector<SharedSurface> {}
 }

--- a/acts-sys/src/geometry/tracking_geometry.rs
+++ b/acts-sys/src/geometry/tracking_geometry.rs
@@ -6,6 +6,19 @@ mod ffi {
         include!("Acts/Geometry/TrackingGeometry.hpp");
 
         type TrackingGeometry;
+
+        type GeometryContext = crate::geometry::geometry_context::GeometryContext;
+        type IVisualization3D = crate::visualization::i_visualization3d::IVisualization3D;
+        type ViewConfig = crate::visualization::view_config::ViewConfig;
+
+        fn visualize(
+            self: &TrackingGeometry,
+            helper: Pin<&mut IVisualization3D>,
+            geometry_context: &GeometryContext,
+            global_config: &ViewConfig,
+            portal_config: &ViewConfig,
+            sensitive_config: &ViewConfig,
+        );
     }
 
     impl UniquePtr<TrackingGeometry> {}

--- a/acts-sys/src/lib.rs
+++ b/acts-sys/src/lib.rs
@@ -2,3 +2,4 @@ pub mod definitions;
 pub mod geometry;
 pub mod surfaces;
 pub mod utilities;
+pub mod visualization;

--- a/acts-sys/src/surfaces/cone_surface.rs
+++ b/acts-sys/src/surfaces/cone_surface.rs
@@ -12,6 +12,6 @@ mod ffi {
 
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
-        fn upcast_shared_cone_surface(node: SharedPtr<ConeSurface>) -> SharedPtr<RegularSurface>;
+        fn upcast_shared_cone_surface(cone: SharedPtr<ConeSurface>) -> SharedPtr<RegularSurface>;
     }
 }

--- a/acts-sys/src/surfaces/cylinder_surface.rs
+++ b/acts-sys/src/surfaces/cylinder_surface.rs
@@ -13,7 +13,7 @@ mod ffi {
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
         fn upcast_shared_cylinder_surface(
-            node: SharedPtr<CylinderSurface>,
+            cylinder: SharedPtr<CylinderSurface>,
         ) -> SharedPtr<RegularSurface>;
     }
 }

--- a/acts-sys/src/surfaces/diamond_bounds.rs
+++ b/acts-sys/src/surfaces/diamond_bounds.rs
@@ -21,6 +21,8 @@ mod ffi {
 
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
-        fn upcast_unique_diamond_bounds(node: UniquePtr<DiamondBounds>) -> UniquePtr<PlanarBounds>;
+        fn upcast_unique_diamond_bounds(
+            bounds: UniquePtr<DiamondBounds>,
+        ) -> UniquePtr<PlanarBounds>;
     }
 }

--- a/acts-sys/src/surfaces/disc_surface.rs
+++ b/acts-sys/src/surfaces/disc_surface.rs
@@ -12,6 +12,6 @@ mod ffi {
 
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
-        fn upcast_shared_disc_surface(node: SharedPtr<DiscSurface>) -> SharedPtr<RegularSurface>;
+        fn upcast_shared_disc_surface(disc: SharedPtr<DiscSurface>) -> SharedPtr<RegularSurface>;
     }
 }

--- a/acts-sys/src/surfaces/disc_trapezoid_bounds.rs
+++ b/acts-sys/src/surfaces/disc_trapezoid_bounds.rs
@@ -23,7 +23,7 @@ mod ffi {
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
         fn upcast_unique_disc_trapezoid_bounds(
-            node: UniquePtr<DiscTrapezoidBounds>,
+            bounds: UniquePtr<DiscTrapezoidBounds>,
         ) -> UniquePtr<DiscBounds>;
     }
 }

--- a/acts-sys/src/surfaces/ellipse_bounds.rs
+++ b/acts-sys/src/surfaces/ellipse_bounds.rs
@@ -22,6 +22,8 @@ mod ffi {
 
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
-        fn upcast_unique_ellipse_bounds(node: UniquePtr<EllipseBounds>) -> UniquePtr<PlanarBounds>;
+        fn upcast_unique_ellipse_bounds(
+            bounds: UniquePtr<EllipseBounds>,
+        ) -> UniquePtr<PlanarBounds>;
     }
 }

--- a/acts-sys/src/surfaces/plane_surface.rs
+++ b/acts-sys/src/surfaces/plane_surface.rs
@@ -12,6 +12,7 @@ mod ffi {
 
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
-        fn upcast_shared_plane_surface(node: SharedPtr<PlaneSurface>) -> SharedPtr<RegularSurface>;
+        fn upcast_shared_plane_surface(plane: SharedPtr<PlaneSurface>)
+        -> SharedPtr<RegularSurface>;
     }
 }

--- a/acts-sys/src/surfaces/radial_bounds.rs
+++ b/acts-sys/src/surfaces/radial_bounds.rs
@@ -20,6 +20,6 @@ mod ffi {
 
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
-        fn upcast_unique_radial_bounds(node: UniquePtr<RadialBounds>) -> UniquePtr<DiscBounds>;
+        fn upcast_unique_radial_bounds(bounds: UniquePtr<RadialBounds>) -> UniquePtr<DiscBounds>;
     }
 }

--- a/acts-sys/src/surfaces/rectangle_bounds.rs
+++ b/acts-sys/src/surfaces/rectangle_bounds.rs
@@ -16,7 +16,7 @@ mod ffi {
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
         fn upcast_unique_rectangle_bounds(
-            node: UniquePtr<RectangleBounds>,
+            bounds: UniquePtr<RectangleBounds>,
         ) -> UniquePtr<PlanarBounds>;
     }
 }

--- a/acts-sys/src/surfaces/regular_surface.rs
+++ b/acts-sys/src/surfaces/regular_surface.rs
@@ -11,6 +11,6 @@ mod ffi {
 
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
-        fn upcast_shared_regular_surface(node: SharedPtr<RegularSurface>) -> SharedPtr<Surface>;
+        fn upcast_shared_regular_surface(surface: SharedPtr<RegularSurface>) -> SharedPtr<Surface>;
     }
 }

--- a/acts-sys/src/surfaces/trapezoid_bounds.rs
+++ b/acts-sys/src/surfaces/trapezoid_bounds.rs
@@ -21,7 +21,7 @@ mod ffi {
         #[namespace = "acts_sys::ffi"]
         #[cxx_name = "upcast"]
         fn upcast_unique_trapezoid_bounds(
-            node: UniquePtr<TrapezoidBounds>,
+            bounds: UniquePtr<TrapezoidBounds>,
         ) -> UniquePtr<PlanarBounds>;
     }
 }

--- a/acts-sys/src/visualization.rs
+++ b/acts-sys/src/visualization.rs
@@ -1,0 +1,1 @@
+pub mod i_visualization3d;

--- a/acts-sys/src/visualization.rs
+++ b/acts-sys/src/visualization.rs
@@ -1,1 +1,2 @@
 pub mod i_visualization3d;
+pub mod obj_visualization3d;

--- a/acts-sys/src/visualization.rs
+++ b/acts-sys/src/visualization.rs
@@ -1,2 +1,3 @@
 pub mod i_visualization3d;
 pub mod obj_visualization3d;
+pub mod view_config;

--- a/acts-sys/src/visualization/i_visualization3d.rs
+++ b/acts-sys/src/visualization/i_visualization3d.rs
@@ -1,0 +1,12 @@
+pub use ffi::*;
+
+#[cxx::bridge(namespace = "Acts")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("Acts/Visualization/IVisualization3D.hpp");
+
+        type IVisualization3D;
+    }
+
+    impl UniquePtr<IVisualization3D> {}
+}

--- a/acts-sys/src/visualization/i_visualization3d.rs
+++ b/acts-sys/src/visualization/i_visualization3d.rs
@@ -4,8 +4,12 @@ pub use ffi::*;
 mod ffi {
     unsafe extern "C++" {
         include!("Acts/Visualization/IVisualization3D.hpp");
+        include!("acts-sys/include/visualization/i_visualization3d.hpp");
 
         type IVisualization3D;
+
+        #[namespace = "acts_sys::ffi"]
+        fn i_visualization3d_write(vis: &IVisualization3D, path: &CxxString);
     }
 
     impl UniquePtr<IVisualization3D> {}

--- a/acts-sys/src/visualization/obj_visualization3d.rs
+++ b/acts-sys/src/visualization/obj_visualization3d.rs
@@ -1,0 +1,22 @@
+pub use ffi::*;
+
+#[cxx::bridge(namespace = "Acts")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("Acts/Visualization/ObjVisualization3D.hpp");
+        include!("acts-sys/include/helpers.hpp");
+
+        type ObjVisualization3D;
+        type IVisualization3D = crate::visualization::i_visualization3d::IVisualization3D;
+
+        #[namespace = "acts_sys::ffi"]
+        #[cxx_name = "make_unique"]
+        fn new_obj_visualization3d(precision: u32, scale: f64) -> UniquePtr<ObjVisualization3D>;
+
+        #[namespace = "acts_sys::ffi"]
+        #[cxx_name = "upcast"]
+        fn upcast_unique_obj_visualization3d(
+            obj: UniquePtr<ObjVisualization3D>,
+        ) -> UniquePtr<IVisualization3D>;
+    }
+}

--- a/acts-sys/src/visualization/view_config.rs
+++ b/acts-sys/src/visualization/view_config.rs
@@ -8,6 +8,7 @@ mod ffi {
 
         type ViewConfig;
 
+        #[allow(clippy::too_many_arguments)]
         #[namespace = "acts_sys::ffi"]
         fn new_view_config(
             visible: bool,

--- a/acts-sys/src/visualization/view_config.rs
+++ b/acts-sys/src/visualization/view_config.rs
@@ -1,0 +1,23 @@
+pub use ffi::*;
+
+#[cxx::bridge(namespace = "Acts")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("Acts/Visualization/ViewConfig.hpp");
+        include!("acts-sys/include/visualization/view_config.hpp");
+
+        type ViewConfig;
+
+        #[namespace = "acts_sys::ffi"]
+        fn new_view_config(
+            visible: bool,
+            rgb_color: &[i32; 3],
+            offset: f64,
+            line_thickness: f64,
+            surface_thickness: f64,
+            quarter_segments: u32,
+            triangulate: bool,
+            output_name: &CxxString,
+        ) -> UniquePtr<ViewConfig>;
+    }
+}


### PR DESCRIPTION
I managed to construct and visualize a tracking geometry like:
```rust
use acts_sys::definitions::algebra;
use acts_sys::geometry::{
    blueprint, blueprint_options, extent, geometry_context, layer_blueprint_node,
    static_blueprint_node,
};
use acts_sys::surfaces::{disc_surface, radial_bounds, regular_surface, surface};
use acts_sys::utilities::logger;
use acts_sys::visualization::{i_visualization3d, obj_visualization3d, view_config};
use cxx::{CxxVector, SharedPtr, let_cxx_string};

fn main() {
    let transform = algebra::make_transform3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
    let bounds: SharedPtr<_> = radial_bounds::upcast_unique_radial_bounds(
        radial_bounds::new_radial_bounds(10.0, 20.0, std::f64::consts::PI / 10.0, 0.0),
    )
    .into();

    let surface =
        regular_surface::upcast_shared_regular_surface(disc_surface::upcast_shared_disc_surface(
            surface::make_shared_disc_surface(&transform, bounds),
        ));
    let mut surfaces = CxxVector::new();
    surfaces
        .pin_mut()
        .push(layer_blueprint_node::SharedSurface { ptr: surface });
    let envelope = extent::new_extent_envelope(
        &[0.0, 0.0],
        &[0.0, 0.0],
        &[1.0, 1.0],
        &[1.0, 1.0],
        &[0.0, 0.0],
        &[0.0, 0.0],
        &[0.0, 0.0],
        &[0.0, 0.0],
        &[0.0, 0.0],
    );

    let_cxx_string!(name = "my_first_geometry");
    let mut layer = layer_blueprint_node::new_layer_blueprint_node(&name);
    layer_blueprint_node::layer_blueprint_node_set_surfaces(layer.pin_mut(), &surfaces);
    layer.pin_mut().set_extent_envelope(&envelope);
    layer
        .pin_mut()
        .set_use_center_of_gravity(false, false, false);
    layer
        .pin_mut()
        .set_layer_type(layer_blueprint_node::LayerBlueprintNodeLayerType::Disc);

    let child = static_blueprint_node::upcast_unique_static_blueprint_node(
        layer_blueprint_node::upcast_unique_layer_blueprint_node(layer),
    );

    let cfg = blueprint::new_blueprint_config(&envelope);
    let mut root = blueprint::new_blueprint(&cfg);
    blueprint::blueprint_add_child(root.pin_mut(), child.into()).unwrap();

    let optiones = blueprint_options::new_blueprint_options();
    let gctx = geometry_context::new_geometry_context();
    let logger = logger::get_dummy_logger();
    let tracking_geometry = root.pin_mut().construct(&optiones, &gctx, logger);

    let mut helper = obj_visualization3d::upcast_unique_obj_visualization3d(
        obj_visualization3d::new_obj_visualization3d(4, 1.0),
    );
    let_cxx_string!(global_name = "test_global");
    let global_cfg =
        view_config::new_view_config(true, &[255, 0, 0], 0.1, 0.15, 0.15, 72, false, &global_name);
    let_cxx_string!(portal_name = "test_portal");
    let portal_cfg =
        view_config::new_view_config(true, &[255, 0, 0], 0.1, 0.15, 0.15, 72, false, &portal_name);
    let_cxx_string!(sensitive_name = "test_sensitive");
    let sensitive_cfg = view_config::new_view_config(
        true,
        &[255, 0, 0],
        0.1,
        0.15,
        0.15,
        72,
        false,
        &sensitive_name,
    );

    tracking_geometry.visualize(
        helper.pin_mut(),
        &gctx,
        &global_cfg,
        &portal_cfg,
        &sensitive_cfg,
    );

    let_cxx_string!(output = "test_output");
    i_visualization3d::i_visualization3d_write(&helper, &output);
}
```

<img width="1568" height="877" alt="my_first_geometry" src="https://github.com/user-attachments/assets/b2023044-8b24-4314-bdae-865074145c93" />

Obviously the raw bindings are far from idiomatic, but it works!